### PR TITLE
Implement KMS abstraction with local provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A secure, user-centric vault for agent frameworks to store and manage personal c
 - **Milestone M1:** Repository initialized with LICENSE, README, and .gitignore.
 - **Milestone M2:** Service skeleton with FastAPI, Docker, tests, and CI pipeline.
 - **Milestone M3:** Storage layer with SQLAlchemy models, migrations, and SQLite support.
+- **Milestone M4:** KMS abstraction with local stub and Vault/AWS providers.
 
 ## Repository Structure
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ fastapi = "^0.110"
 uvicorn = "^0.29"
 SQLAlchemy = "^2.0"
 alembic = "^1.13"
+cryptography = "^42.0"
+hvac = "^1.3"
+boto3 = "^1.34"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4"

--- a/src/kms/aws_kms.py
+++ b/src/kms/aws_kms.py
@@ -1,0 +1,36 @@
+import boto3
+
+from src.kms.base import KMSInterface
+
+
+class AWSKMS(KMSInterface):
+    """AWS KMS provider using boto3."""
+
+    def __init__(self, region_name: str) -> None:
+        self.client = boto3.client("kms", region_name=region_name)
+
+    def generate_key(self, key_id: str) -> None:
+        resp = self.client.create_key(Description=key_id)
+        key_arn = resp["KeyMetadata"]["KeyId"]
+        self.client.create_alias(
+            AliasName=f"alias/{key_id}",
+            TargetKeyId=key_arn,
+        )
+
+    def get_signer(self, key_id: str):
+        return lambda data: self.client.sign(
+            KeyId=f"alias/{key_id}",
+            Message=data,
+            MessageType="RAW",
+        )["Signature"]
+
+    def encrypt(self, key_id: str, plaintext: bytes) -> bytes:
+        resp = self.client.encrypt(
+            KeyId=f"alias/{key_id}",
+            Plaintext=plaintext,
+        )
+        return resp["CiphertextBlob"]
+
+    def decrypt(self, key_id: str, ciphertext: bytes) -> bytes:
+        resp = self.client.decrypt(CiphertextBlob=ciphertext)
+        return resp["Plaintext"]

--- a/src/kms/base.py
+++ b/src/kms/base.py
@@ -1,0 +1,25 @@
+from abc import ABC, abstractmethod
+
+
+class KMSInterface(ABC):
+    """Abstract Key Management Service interface."""
+
+    @abstractmethod
+    def generate_key(self, key_id: str) -> None:
+        """Generate a new key with the given key_id."""
+        pass
+
+    @abstractmethod
+    def get_signer(self, key_id: str):
+        """Return a callable that signs bytes."""
+        pass
+
+    @abstractmethod
+    def encrypt(self, key_id: str, plaintext: bytes) -> bytes:
+        """Encrypt data using key_id."""
+        pass
+
+    @abstractmethod
+    def decrypt(self, key_id: str, ciphertext: bytes) -> bytes:
+        """Decrypt data using key_id."""
+        pass

--- a/src/kms/local_kms.py
+++ b/src/kms/local_kms.py
@@ -1,0 +1,30 @@
+import os
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from src.kms.base import KMSInterface
+
+
+class LocalKMS(KMSInterface):
+    """Software-based KMS stub storing keys in-memory (for dev)."""
+
+    def __init__(self) -> None:
+        self._keys: dict[str, bytes] = {}
+
+    def generate_key(self, key_id: str) -> None:
+        key = AESGCM.generate_key(bit_length=256)
+        self._keys[key_id] = key
+
+    def get_signer(self, key_id: str):
+        raise NotImplementedError("LocalKMS does not support signing")
+
+    def encrypt(self, key_id: str, plaintext: bytes) -> bytes:
+        key = self._keys[key_id]
+        aesgcm = AESGCM(key)
+        nonce = os.urandom(12)
+        return nonce + aesgcm.encrypt(nonce, plaintext, None)
+
+    def decrypt(self, key_id: str, ciphertext: bytes) -> bytes:
+        key = self._keys[key_id]
+        aesgcm = AESGCM(key)
+        nonce, ct = ciphertext[:12], ciphertext[12:]
+        return aesgcm.decrypt(nonce, ct, None)

--- a/src/kms/vault_kms.py
+++ b/src/kms/vault_kms.py
@@ -1,0 +1,45 @@
+import hvac
+
+from src.kms.base import KMSInterface
+
+
+class VaultKMS(KMSInterface):
+    """HashiCorp Vault KMS provider."""
+
+    def __init__(
+        self,
+        url: str,
+        token: str,
+        mount_point: str = "transit",
+    ) -> None:
+        self.client = hvac.Client(url=url, token=token)
+        self.mount = mount_point
+
+    def generate_key(self, key_id: str) -> None:
+        self.client.secrets.transit.create_key(
+            name=key_id,
+            mount_point=self.mount,
+        )
+
+    def get_signer(self, key_id: str):
+        return lambda data: self.client.secrets.transit.sign_data(
+            name=key_id,
+            input=data,
+            mount_point=self.mount,
+        )["data"]["signature"]
+
+    def encrypt(self, key_id: str, plaintext: bytes) -> bytes:
+        result = self.client.secrets.transit.encrypt_data(
+            name=key_id,
+            plaintext=plaintext.hex(),
+            mount_point=self.mount,
+        )
+        return bytes.fromhex(result["data"]["ciphertext"])
+
+    def decrypt(self, key_id: str, ciphertext: bytes) -> bytes:
+        result = self.client.secrets.transit.decrypt_data(
+            name=key_id,
+            ciphertext=ciphertext.hex(),
+            mount_point=self.mount,
+        )
+        return bytes.fromhex(result["data"]["plaintext"])

--- a/tests/test_kms.py
+++ b/tests/test_kms.py
@@ -1,0 +1,30 @@
+import pytest
+
+from src.kms.base import KMSInterface
+from src.kms.local_kms import LocalKMS
+
+
+@pytest.fixture
+def kms() -> LocalKMS:
+    kms = LocalKMS()
+    return kms
+
+
+def test_local_kms_implements_interface(kms):
+    assert isinstance(kms, KMSInterface)
+
+
+def test_encrypt_roundtrip(kms):
+    key_id = "test"
+    kms.generate_key(key_id)
+    plaintext = b"secret-data"
+    ciphertext = kms.encrypt(key_id, plaintext)
+    assert ciphertext != plaintext
+    decrypted = kms.decrypt(key_id, ciphertext)
+    assert decrypted == plaintext
+
+
+def test_signer_not_implemented(kms):
+    kms.generate_key("sig")
+    with pytest.raises(NotImplementedError):
+        kms.get_signer("sig")


### PR DESCRIPTION
## Summary
- add Milestone M4 to README
- introduce pluggable KMS package with `KMSInterface`
- implement LocalKMS, VaultKMS and AWSKMS providers
- extend dependencies for KMS libraries
- add unit tests for LocalKMS functionality

## Testing
- `flake8 src tests`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68479c49fad88321ba85679bef6c6b33