### PR TITLE
Add credential API with tests

### DIFF
--- a/src/api/credentials.py
+++ b/src/api/credentials.py
@@ -1,0 +1,80 @@
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from src.storage.database import get_db
+from src.storage.models import Credential, CredentialStatus
+from src.kms.local_kms import LocalKMS
+
+router = APIRouter()
+
+# simple in-memory KMS instance for demo purposes
+kms = LocalKMS()
+kms.generate_key("default")
+
+
+class CredentialIn(BaseModel):
+    user_id: str
+    cred_type: str
+    blob: str
+
+
+class CredentialOut(BaseModel):
+    user_id: str
+    cred_type: str
+    status: CredentialStatus
+    blob: str
+
+
+@router.post("/", response_model=CredentialOut, tags=["Credentials"])
+async def create_credential(data: CredentialIn, db: Session = Depends(get_db)):
+    ciphertext = kms.encrypt("default", data.blob.encode())
+    cred = Credential(
+        user_id=data.user_id,
+        cred_type=data.cred_type,
+        blob=ciphertext,
+    )
+    db.add(cred)
+    db.commit()
+    db.refresh(cred)
+    plaintext = kms.decrypt("default", cred.blob).decode()
+    return CredentialOut(
+        user_id=cred.user_id,
+        cred_type=cred.cred_type,
+        status=cred.status,
+        blob=plaintext,
+    )
+
+
+@router.get("/{user_id}/{cred_type}",
+            response_model=CredentialOut,
+            tags=["Credentials"])
+async def get_credential(
+    user_id: str, cred_type: str, db: Session = Depends(get_db)
+):
+    cred = db.query(Credential).filter_by(
+        user_id=user_id, cred_type=cred_type
+    ).first()
+    if not cred:
+        raise HTTPException(status_code=404, detail="Credential not found")
+    plaintext = kms.decrypt("default", cred.blob).decode()
+    return CredentialOut(
+        user_id=cred.user_id,
+        cred_type=cred.cred_type,
+        status=cred.status,
+        blob=plaintext,
+    )
+
+
+@router.post("/{user_id}/{cred_type}/revoke", tags=["Credentials"])
+async def revoke_credential(
+    user_id: str, cred_type: str, db: Session = Depends(get_db)
+):
+    cred = db.query(Credential).filter_by(
+        user_id=user_id, cred_type=cred_type
+    ).first()
+    if not cred:
+        raise HTTPException(status_code=404, detail="Credential not found")
+    cred.status = CredentialStatus.revoked
+    db.commit()
+    return {"status": "revoked"}

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,10 @@
 from fastapi import FastAPI
 from src.api.health import router as health_router
+from src.api.credentials import router as credentials_router
 
 app = FastAPI(title="Personal Data Vault Service")
 app.include_router(health_router, prefix="/health")
+app.include_router(credentials_router, prefix="/credentials")
 
 if __name__ == "__main__":
     import uvicorn

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,43 @@
+import os
+import pytest
+from fastapi.testclient import TestClient
+from src.main import app
+from src.storage.database import Base, engine
+
+client = TestClient(app)
+
+
+TEST_DB = "sqlite:///./test_api.db"
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    os.environ["DATABASE_URL"] = TEST_DB
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+    if os.path.exists("test_api.db"):
+        os.remove("test_api.db")
+
+
+def test_create_and_get_credential():
+    payload = {"user_id": "u1", "cred_type": "Test", "blob": "secret"}
+    resp = client.post("/credentials/", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["blob"] == "secret"
+
+    resp_get = client.get("/credentials/u1/Test")
+    assert resp_get.status_code == 200
+    assert resp_get.json()["blob"] == "secret"
+
+
+def test_revoke_credential():
+    payload = {"user_id": "u2", "cred_type": "Test", "blob": "data"}
+    client.post("/credentials/", json=payload)
+    resp = client.post("/credentials/u2/Test/revoke")
+    assert resp.status_code == 200
+
+    resp_get = client.get("/credentials/u2/Test")
+    assert resp_get.status_code == 200
+    assert resp_get.json()["status"] == "revoked"


### PR DESCRIPTION
## Summary
- implement `credentials` API routes for creating, retrieving and revoking
- wire credential routes into FastAPI app
- test credential endpoints

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847ab4239688321938f8c205138da40