### PR TITLE
Add MCP server and mount into FastAPI app

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,5 +54,9 @@ pdv-vault/
 docker-compose up --build
 ```
 
+### MCP Server
+
+This repo now includes a small [Model Context Protocol](https://modelcontextprotocol.io/) server exposing PDV functionality as MCP tools. The server lives in `src/mcp_server.py` and is mounted under `/mcp` when running the FastAPI app. Any MCP compatible client (e.g. Claude Desktop) can connect to this endpoint to invoke the credential tools.
+
 ## Contribution
 See CONTRIBUTING.md for guidelines.

--- a/src/main.py
+++ b/src/main.py
@@ -1,10 +1,12 @@
 from fastapi import FastAPI
 from src.api.health import router as health_router
 from src.api.credentials import router as credentials_router
+from src.mcp_server import mcp
 
 app = FastAPI(title="Personal Data Vault Service")
 app.include_router(health_router, prefix="/health")
 app.include_router(credentials_router, prefix="/credentials")
+app.mount("/mcp", mcp.streamable_http_app())
 
 if __name__ == "__main__":
     import uvicorn

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -1,0 +1,53 @@
+from mcp.server.fastmcp import FastMCP
+from src.storage.database import SessionLocal
+from src.storage.models import Credential, CredentialStatus
+from src.kms.local_kms import LocalKMS
+
+mcp = FastMCP("PDV MCP", stateless_http=True)
+
+_kms = LocalKMS()
+_kms.generate_key("default")
+
+@mcp.tool(description="Create a new credential")
+def create_credential(user_id: str, cred_type: str, blob: str) -> dict:
+    with SessionLocal() as db:
+        ciphertext = _kms.encrypt("default", blob.encode())
+        cred = Credential(user_id=user_id, cred_type=cred_type, blob=ciphertext)
+        db.add(cred)
+        db.commit()
+        db.refresh(cred)
+        plaintext = _kms.decrypt("default", cred.blob).decode()
+        return {
+            "user_id": cred.user_id,
+            "cred_type": cred.cred_type,
+            "status": cred.status.value,
+            "blob": plaintext,
+        }
+
+@mcp.tool(description="Retrieve a credential")
+def get_credential(user_id: str, cred_type: str) -> dict:
+    with SessionLocal() as db:
+        cred = db.query(Credential).filter_by(user_id=user_id, cred_type=cred_type).first()
+        if not cred:
+            raise ValueError("Credential not found")
+        plaintext = _kms.decrypt("default", cred.blob).decode()
+        return {
+            "user_id": cred.user_id,
+            "cred_type": cred.cred_type,
+            "status": cred.status.value,
+            "blob": plaintext,
+        }
+
+@mcp.tool(description="Revoke a credential")
+def revoke_credential(user_id: str, cred_type: str) -> dict:
+    with SessionLocal() as db:
+        cred = db.query(Credential).filter_by(user_id=user_id, cred_type=cred_type).first()
+        if not cred:
+            raise ValueError("Credential not found")
+        cred.status = CredentialStatus.revoked
+        db.commit()
+        return {"status": "revoked"}
+
+@mcp.resource("pdv://health")
+def health() -> str:
+    return "healthy"


### PR DESCRIPTION
## Summary
- integrate the Model Context Protocol (MCP) server
- expose credential operations as MCP tools
- mount the MCP server under `/mcp`
- document the MCP server in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d9b1f744832183098a99ba26f492