### PR TITLE
Implement policy engine and proof tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,13 @@ docker-compose up --build
 
 ### MCP Server
 
-This repo now includes a small [Model Context Protocol](https://modelcontextprotocol.io/) server exposing PDV functionality as MCP tools. The server lives in `src/mcp_server.py` and is mounted under `/mcp` when running the FastAPI app. Any MCP compatible client (e.g. Claude Desktop) can connect to this endpoint to invoke the credential tools.
+This repo now includes a small [Model Context Protocol](https://modelcontextprotocol.io/) server exposing PDV functionality as MCP tools. The server lives in `src/mcp_server.py` and is mounted under `/mcp` when running the FastAPI app. Any MCP compatible client (e.g. Claude Desktop) can connect to this endpoint to invoke the PDV tools.
+
+Current tools include:
+
+- **Credential Manager** – create, retrieve and revoke credentials.
+- **Policy & Consent Engine** – record and check user consent decisions.
+- **Proof Generation** – generate a simple signed proof for arbitrary data.
 
 ## Contribution
 See CONTRIBUTING.md for guidelines.

--- a/src/api/consents.py
+++ b/src/api/consents.py
@@ -1,0 +1,43 @@
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+import uuid
+
+from src.storage.database import get_db
+from src.storage.models import Consent, ConsentDecision
+
+router = APIRouter()
+
+class ConsentIn(BaseModel):
+    user_id: str
+    service: str
+    scope: str
+    decision: ConsentDecision
+
+class ConsentOut(BaseModel):
+    id: str
+    user_id: str
+    service: str
+    scope: str
+    decision: ConsentDecision
+
+@router.post("/", response_model=ConsentOut, tags=["Consents"])
+async def record_consent(data: ConsentIn, db: Session = Depends(get_db)):
+    consent = Consent(
+        id=str(uuid.uuid4()),
+        user_id=data.user_id,
+        service=data.service,
+        scope=data.scope,
+        decision=data.decision,
+    )
+    db.add(consent)
+    db.commit()
+    db.refresh(consent)
+    return consent
+
+@router.get("/{user_id}", response_model=list[ConsentOut], tags=["Consents"])
+async def list_consents(user_id: str, service: str | None = None, db: Session = Depends(get_db)):
+    query = db.query(Consent).filter_by(user_id=user_id)
+    if service:
+        query = query.filter_by(service=service)
+    return query.all()

--- a/src/api/credentials.py
+++ b/src/api/credentials.py
@@ -4,13 +4,11 @@ from sqlalchemy.orm import Session
 
 from src.storage.database import get_db
 from src.storage.models import Credential, CredentialStatus
-from src.kms.local_kms import LocalKMS
+from src.kms.registry import kms
 
 router = APIRouter()
 
-# simple in-memory KMS instance for demo purposes
-kms = LocalKMS()
-kms.generate_key("default")
+# KMS instance is shared across the service
 
 
 class CredentialIn(BaseModel):

--- a/src/api/proof.py
+++ b/src/api/proof.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+from src.kms.registry import kms
+
+router = APIRouter()
+
+class ProofRequest(BaseModel):
+    data: str
+
+class ProofResponse(BaseModel):
+    proof: str
+
+@router.post("/", response_model=ProofResponse, tags=["Proofs"])
+async def generate_proof(req: ProofRequest):
+    signer = kms.get_signer("default")
+    sig = signer(req.data.encode()).hex()
+    return ProofResponse(proof=sig)

--- a/src/kms/__init__.py
+++ b/src/kms/__init__.py
@@ -1,0 +1,5 @@
+from .base import KMSInterface
+from .local_kms import LocalKMS
+from .registry import kms
+
+__all__ = ["KMSInterface", "LocalKMS", "kms"]

--- a/src/kms/local_kms.py
+++ b/src/kms/local_kms.py
@@ -1,5 +1,7 @@
 import os
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.hmac import HMAC
+from cryptography.hazmat.primitives import hashes
 
 from src.kms.base import KMSInterface
 
@@ -15,7 +17,14 @@ class LocalKMS(KMSInterface):
         self._keys[key_id] = key
 
     def get_signer(self, key_id: str):
-        raise NotImplementedError("LocalKMS does not support signing")
+        key = self._keys[key_id]
+
+        def signer(message: bytes) -> bytes:
+            h = HMAC(key, hashes.SHA256())
+            h.update(message)
+            return h.finalize()
+
+        return signer
 
     def encrypt(self, key_id: str, plaintext: bytes) -> bytes:
         key = self._keys[key_id]

--- a/src/kms/registry.py
+++ b/src/kms/registry.py
@@ -1,0 +1,6 @@
+from src.kms.local_kms import LocalKMS
+
+# Singleton KMS instance shared across modules
+kms = LocalKMS()
+# generate a default key on startup
+kms.generate_key("default")

--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,15 @@
 from fastapi import FastAPI
 from src.api.health import router as health_router
 from src.api.credentials import router as credentials_router
+from src.api.consents import router as consents_router
+from src.api.proof import router as proof_router
 from src.mcp_server import mcp
 
 app = FastAPI(title="Personal Data Vault Service")
 app.include_router(health_router, prefix="/health")
 app.include_router(credentials_router, prefix="/credentials")
+app.include_router(consents_router, prefix="/consents")
+app.include_router(proof_router, prefix="/proof")
 app.mount("/mcp", mcp.streamable_http_app())
 
 if __name__ == "__main__":

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -1,22 +1,26 @@
 from mcp.server.fastmcp import FastMCP
+import uuid
 from src.storage.database import SessionLocal
-from src.storage.models import Credential, CredentialStatus
-from src.kms.local_kms import LocalKMS
+from src.storage.models import (
+    Credential,
+    CredentialStatus,
+    Consent,
+    ConsentDecision,
+)
+from src.kms.registry import kms
 
 mcp = FastMCP("PDV MCP", stateless_http=True)
 
-_kms = LocalKMS()
-_kms.generate_key("default")
 
 @mcp.tool(description="Create a new credential")
 def create_credential(user_id: str, cred_type: str, blob: str) -> dict:
     with SessionLocal() as db:
-        ciphertext = _kms.encrypt("default", blob.encode())
+        ciphertext = kms.encrypt("default", blob.encode())
         cred = Credential(user_id=user_id, cred_type=cred_type, blob=ciphertext)
         db.add(cred)
         db.commit()
         db.refresh(cred)
-        plaintext = _kms.decrypt("default", cred.blob).decode()
+        plaintext = kms.decrypt("default", cred.blob).decode()
         return {
             "user_id": cred.user_id,
             "cred_type": cred.cred_type,
@@ -30,7 +34,7 @@ def get_credential(user_id: str, cred_type: str) -> dict:
         cred = db.query(Credential).filter_by(user_id=user_id, cred_type=cred_type).first()
         if not cred:
             raise ValueError("Credential not found")
-        plaintext = _kms.decrypt("default", cred.blob).decode()
+        plaintext = kms.decrypt("default", cred.blob).decode()
         return {
             "user_id": cred.user_id,
             "cred_type": cred.cred_type,
@@ -47,6 +51,49 @@ def revoke_credential(user_id: str, cred_type: str) -> dict:
         cred.status = CredentialStatus.revoked
         db.commit()
         return {"status": "revoked"}
+
+
+@mcp.tool(description="Record a user consent decision")
+def record_consent(user_id: str, service: str, scope: str, decision: str) -> dict:
+    with SessionLocal() as db:
+        consent = Consent(
+            id=str(uuid.uuid4()),
+            user_id=user_id,
+            service=service,
+            scope=scope,
+            decision=ConsentDecision(decision),
+        )
+        db.add(consent)
+        db.commit()
+        db.refresh(consent)
+        return {
+            "id": consent.id,
+            "user_id": consent.user_id,
+            "service": consent.service,
+            "scope": consent.scope,
+            "decision": consent.decision.value,
+        }
+
+
+@mcp.tool(description="Check the latest consent decision for a scope")
+def check_consent(user_id: str, service: str, scope: str) -> dict:
+    with SessionLocal() as db:
+        consent = (
+            db.query(Consent)
+            .filter_by(user_id=user_id, service=service, scope=scope)
+            .order_by(Consent.timestamp.desc())
+            .first()
+        )
+        if not consent:
+            return {"decision": "none"}
+        return {"decision": consent.decision.value}
+
+
+@mcp.tool(description="Generate a signed proof of data")
+def generate_proof(data: str) -> dict:
+    signer = kms.get_signer("default")
+    signature = signer(data.encode()).hex()
+    return {"proof": signature}
 
 @mcp.resource("pdv://health")
 def health() -> str:

--- a/src/storage/models.py
+++ b/src/storage/models.py
@@ -29,3 +29,18 @@ class Credential(Base):
     status = Column(Enum(CredentialStatus), default=CredentialStatus.active)
     metadata_ = Column("metadata", JSON)
     blob = Column(BLOB, nullable=False)  # encrypted credential payload
+
+
+class ConsentDecision(enum.Enum):
+    granted = "granted"
+    denied = "denied"
+
+
+class Consent(Base):
+    __tablename__ = "consents"
+    id = Column(String, primary_key=True)
+    user_id = Column(String, index=True)
+    service = Column(String, index=True)
+    scope = Column(String)
+    decision = Column(Enum(ConsentDecision))
+    timestamp = Column(DateTime, default=datetime.utcnow)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure src package is importable
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_consents.py
+++ b/tests/test_consents.py
@@ -1,0 +1,31 @@
+import os
+import pytest
+from fastapi.testclient import TestClient
+from src.main import app
+from src.storage.database import Base, engine
+
+client = TestClient(app)
+TEST_DB = "sqlite:///./test_consents.db"
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    os.environ["DATABASE_URL"] = TEST_DB
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+    if os.path.exists("test_consents.db"):
+        os.remove("test_consents.db")
+
+
+def test_record_and_list_consent():
+    payload = {"user_id": "u1", "service": "svc", "scope": "email", "decision": "granted"}
+    resp = client.post("/consents/", json=payload)
+    assert resp.status_code == 200
+    consent_id = resp.json()["id"]
+
+    resp_list = client.get("/consents/u1?service=svc")
+    assert resp_list.status_code == 200
+    data = resp_list.json()
+    assert len(data) == 1
+    assert data[0]["id"] == consent_id

--- a/tests/test_kms.py
+++ b/tests/test_kms.py
@@ -24,7 +24,8 @@ def test_encrypt_roundtrip(kms):
     assert decrypted == plaintext
 
 
-def test_signer_not_implemented(kms):
+def test_get_signer_returns_callable(kms):
     kms.generate_key("sig")
-    with pytest.raises(NotImplementedError):
-        kms.get_signer("sig")
+    signer = kms.get_signer("sig")
+    signature = signer(b"message")
+    assert isinstance(signature, bytes)

--- a/tests/test_proof.py
+++ b/tests/test_proof.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+from src.main import app
+
+client = TestClient(app)
+
+def test_generate_proof():
+    resp = client.post("/proof/", json={"data": "hello"})
+    assert resp.status_code == 200
+    assert "proof" in resp.json()


### PR DESCRIPTION
## Summary
- share a singleton KMS instance across modules
- expose Policy & Consent and Proof Generation tools via API and MCP server
- implement consent models and database support
- add HMAC-based signing in LocalKMS
- update tests for new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ec57bf1083219d153569087edfe0